### PR TITLE
Add simple color-coded calendar web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Calendar with Memos</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>My Calendar</h1>
+        <div id="month-nav">
+            <button id="prev-month">&lt;</button>
+            <span id="current-month"></span>
+            <button id="next-month">&gt;</button>
+        </div>
+    </header>
+    <div id="container">
+        <aside id="sidebar">
+            <h2>Memos</h2>
+            <textarea id="memos" placeholder="Write your notes here..."></textarea>
+            <h2>To-Do List</h2>
+            <input type="text" id="task-input" placeholder="New task...">
+            <button id="add-task">Add</button>
+            <ul id="task-list"></ul>
+        </aside>
+        <main id="calendar-container">
+            <table id="calendar">
+                <thead>
+                    <tr>
+                        <th>Sun</th>
+                        <th>Mon</th>
+                        <th>Tue</th>
+                        <th>Wed</th>
+                        <th>Thu</th>
+                        <th>Fri</th>
+                        <th>Sat</th>
+                    </tr>
+                </thead>
+                <tbody id="calendar-body">
+                    <!-- Days will be generated here -->
+                </tbody>
+            </table>
+        </main>
+    </div>
+
+    <!-- Modal for adding events -->
+    <div id="event-modal" class="hidden">
+        <div id="modal-content">
+            <h3>Add Event</h3>
+            <input type="text" id="event-desc" placeholder="Event description">
+            <label for="event-color">Color:</label>
+            <input type="color" id="event-color" value="#ffd700">
+            <button id="save-event">Save</button>
+            <button id="cancel-event">Cancel</button>
+        </div>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,130 @@
+let currentDate = new Date();
+const calendarBody = document.getElementById('calendar-body');
+const currentMonthSpan = document.getElementById('current-month');
+
+// Load saved data from localStorage
+const memosArea = document.getElementById('memos');
+const taskList = document.getElementById('task-list');
+
+memosArea.value = localStorage.getItem('memos') || '';
+
+function loadTasks() {
+    taskList.innerHTML = '';
+    const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
+    tasks.forEach((task, index) => {
+        const li = document.createElement('li');
+        li.textContent = task;
+        li.addEventListener('click', () => {
+            tasks.splice(index, 1);
+            localStorage.setItem('tasks', JSON.stringify(tasks));
+            loadTasks();
+        });
+        taskList.appendChild(li);
+    });
+}
+
+loadTasks();
+
+document.getElementById('add-task').addEventListener('click', () => {
+    const input = document.getElementById('task-input');
+    const value = input.value.trim();
+    if (value) {
+        const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
+        tasks.push(value);
+        localStorage.setItem('tasks', JSON.stringify(tasks));
+        input.value = '';
+        loadTasks();
+    }
+});
+
+memosArea.addEventListener('input', () => {
+    localStorage.setItem('memos', memosArea.value);
+});
+
+function saveEvents(events) {
+    localStorage.setItem('events', JSON.stringify(events));
+}
+
+function loadEvents() {
+    return JSON.parse(localStorage.getItem('events') || '{}');
+}
+
+function renderCalendar() {
+    calendarBody.innerHTML = '';
+    const year = currentDate.getFullYear();
+    const month = currentDate.getMonth();
+    currentMonthSpan.textContent = currentDate.toLocaleString('default', { month: 'long', year: 'numeric' });
+
+    const firstDay = new Date(year, month, 1).getDay();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+    const events = loadEvents();
+
+    let date = 1;
+    for (let i = 0; i < 6; i++) {
+        const row = document.createElement('tr');
+        for (let j = 0; j < 7; j++) {
+            const cell = document.createElement('td');
+            if (i === 0 && j < firstDay) {
+                cell.innerHTML = '';
+            } else if (date > daysInMonth) {
+                break;
+            } else {
+                const dayDiv = document.createElement('div');
+                dayDiv.classList.add('day-number');
+                dayDiv.textContent = date;
+                cell.appendChild(dayDiv);
+                const key = `${year}-${month}-${date}`;
+                if (events[key]) {
+                    events[key].forEach(evt => {
+                        const evtDiv = document.createElement('div');
+                        evtDiv.classList.add('event');
+                        evtDiv.style.background = evt.color;
+                        evtDiv.textContent = evt.desc;
+                        cell.appendChild(evtDiv);
+                    });
+                }
+                cell.addEventListener('click', () => openModal(key));
+                date++;
+            }
+            row.appendChild(cell);
+        }
+        calendarBody.appendChild(row);
+    }
+}
+
+function openModal(dateKey) {
+    const modal = document.getElementById('event-modal');
+    modal.classList.remove('hidden');
+    document.getElementById('save-event').onclick = () => saveEvent(dateKey);
+    document.getElementById('cancel-event').onclick = closeModal;
+}
+
+function closeModal() {
+    document.getElementById('event-modal').classList.add('hidden');
+    document.getElementById('event-desc').value = '';
+}
+
+function saveEvent(dateKey) {
+    const desc = document.getElementById('event-desc').value.trim();
+    const color = document.getElementById('event-color').value;
+    if (!desc) return;
+    const events = loadEvents();
+    if (!events[dateKey]) events[dateKey] = [];
+    events[dateKey].push({ desc, color });
+    saveEvents(events);
+    closeModal();
+    renderCalendar();
+}
+
+renderCalendar();
+
+document.getElementById('prev-month').addEventListener('click', () => {
+    currentDate.setMonth(currentDate.getMonth() - 1);
+    renderCalendar();
+});
+
+document.getElementById('next-month').addEventListener('click', () => {
+    currentDate.setMonth(currentDate.getMonth() + 1);
+    renderCalendar();
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,87 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+header {
+    margin: 20px 0;
+    text-align: center;
+}
+
+#container {
+    display: flex;
+    width: 90%;
+    max-width: 1000px;
+}
+
+#sidebar {
+    width: 25%;
+    padding: 10px;
+    box-sizing: border-box;
+}
+
+#sidebar textarea {
+    width: 100%;
+    height: 150px;
+}
+
+#calendar-container {
+    width: 75%;
+    padding: 10px;
+    box-sizing: border-box;
+}
+
+#calendar {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#calendar th, #calendar td {
+    border: 1px solid #ccc;
+    width: 14%;
+    height: 100px;
+    vertical-align: top;
+    position: relative;
+}
+
+.day-number {
+    position: absolute;
+    top: 2px;
+    right: 4px;
+    font-size: 12px;
+}
+
+.event {
+    padding: 2px 4px;
+    margin: 2px 0;
+    border-radius: 4px;
+    color: #000;
+    font-size: 12px;
+}
+
+.hidden {
+    display: none;
+}
+
+#event-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#modal-content {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+}


### PR DESCRIPTION
## Summary
- build `index.html` with monthly calendar layout, memo and task sidebar
- implement basic styles in `styles.css`
- add `script.js` with localStorage support for memos, tasks and events

## Testing
- `python3 -m http.server 8000` *(server started successfully)*

------
https://chatgpt.com/codex/tasks/task_e_685a09fba8e483278b3c14724c4c3589