### PR TITLE
Ensure event modal hidden before initial calendar render

### DIFF
--- a/script.js
+++ b/script.js
@@ -105,6 +105,9 @@ function closeModal() {
     document.getElementById('event-desc').value = '';
 }
 
+// Ensure modal is hidden on initial load in case CSS fails to apply
+closeModal();
+
 function saveEvent(dateKey) {
     const desc = document.getElementById('event-desc').value.trim();
     const color = document.getElementById('event-color').value;


### PR DESCRIPTION
## Summary
- hide the event modal at startup to avoid visible modal if CSS fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a195bbf608327820020cf29a8c353